### PR TITLE
Fix the decode_ptypstring() function

### DIFF
--- a/src/parser/outlook.rs
+++ b/src/parser/outlook.rs
@@ -391,7 +391,7 @@ mod tests {
         assert_eq!(
             displays,
             vec![
-                "1 Days Left\u{14} 35% off cloud space, upgrade now!".to_string(),
+                "1 Days Left—35% off cloud space, upgrade now!".to_string(),
                 "milky-way-2695569_960_720.jpg".to_string(),
                 "Test Email.msg".to_string(),
             ]

--- a/src/parser/storage.rs
+++ b/src/parser/storage.rs
@@ -312,7 +312,7 @@ mod tests {
         let attachment_name = storages.attachments[0].get("DisplayName");
         assert_eq!(
             attachment_name,
-            Some(&DataType::PtypString("1 Days Left\u{14} 35% off cloud space, upgrade now!".to_string()))
+            Some(&DataType::PtypString("1 Days Left—35% off cloud space, upgrade now!".to_string()))
         );
 
         let attachment_name = storages.attachments[1].get("AttachFilename");


### PR DESCRIPTION
The previous implementation of `decode_ptypstring()` was incorrect assumed the 8 most significant bits always are zeroes. This new implementation fixes it.