### PR TITLE
Fix hanging MSG parser on non-sequential MSAT tables

### DIFF
--- a/src/ole/header.rs
+++ b/src/ole/header.rs
@@ -135,15 +135,17 @@ impl<'ole> super::ole::Reader<'ole> {
         let relative_offset = sec_id * sec_size;
 
         // check if we need to read more data
-        if buffer.len() <= relative_offset + sec_size {
-          let new_len = (sec_id + 1) * sec_size;
+        if buffer.len() < relative_offset + sec_size {
+          let old_len = buffer.len();
+          let new_len = relative_offset + sec_size;
           buffer.resize(new_len, 0xFFu8);
-          self.read(&mut buffer[relative_offset
-            .. relative_offset + sec_size])?;
+          self.read(&mut buffer[old_len..new_len])?;
         }
+
         total_sec_id_read += self.read_sec_ids(&buffer[relative_offset
           .. relative_offset + sec_size - 4], total_sec_id_read);
-        sec_id = usize::from_slice(&buffer[buffer.len() - 4 ..]);
+        sec_id = usize::from_slice(&buffer[relative_offset + sec_size - 4
+          .. relative_offset + sec_size]);
       }
         // save the buffer for later usage
         self.body = Some(buffer);


### PR DESCRIPTION
This PR addresses issue #2. For less than 1% of the emails in a dataset I'm working with, the MSG parser would hang. I believe this occurs when the MSG files contain an MSAT table that is not sequential (e.g., sector 0 -> sector 1 -> sector 2 -> ...). According to [this OpenOffice doc](https://www.openoffice.org/sc/compdocfileformat.pdf), skipping sectors or going backward seems allowed:

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/1489115/231196440-b13993ff-5148-41b9-83f4-c198208825e9.png">

If the MSAT has backwards jumps, then the original code would read the next `sec_id` (`sec_id = usize::from_slice`) from the wrong part of the buffer. It would read from the end of the loaded buffer, but should read from the location defined by `sec_id`.

If the MSAT skips sectors (eg. sector 0 -> sector 5 -> sector 6), then the original code would read (`self.read(&mut buffer...)`) from the wrong place in the file. In this example it would read sector 1 from the file, but save it as sector 5 in the buffer. 

Unfortunately I can't make the test files I have public. On my private dataset I don't see any more hangs and emails still generally seem to parse properly.

I also added an extra check in case the MSAT chain contains some kind of loop. This should stop the parser from looping forever on a malicious or corrupted file.