### PR TITLE
r"(?im)^

### DIFF
--- a/src/parser/outlook.rs
+++ b/src/parser/outlook.rs
@@ -131,7 +131,7 @@ impl Outlook {
     fn extract_cc_from_headers(header_text: &str) -> Vec<Person> {
         // Format in header is:
         // CC: NAME <EMAIL>, NAME <EMAIL> \r\n
-        let re = Regex::new(r"(?im)CC: .*(\r\n\t)?.*\r\n").unwrap();
+        let re = Regex::new(r"(?im)^CC: .*(\r\n\t)?.*\r\n").unwrap();
         let caps = re.captures(header_text);
         if caps.is_none() {
             return vec![];

--- a/src/parser/outlook.rs
+++ b/src/parser/outlook.rs
@@ -49,16 +49,16 @@ impl TransportHeaders {
         Self {
             content_type: Self::extract_field(
                 text,
-                Regex::new(r"(?i)Content-Type: (.*(\n\s.*)*)\r\n").unwrap(),
+                Regex::new(r"(?im)^Content-Type: (.*(\n\s.*)*)\r\n").unwrap(),
             ),
             date: Self::extract_field(&text, Regex::new(r"(?i)Date: (.*(\n\s.*)*)\r\n").unwrap()),
             message_id: Self::extract_field(
                 text,
-                Regex::new(r"(?i)Message-ID: (.*(\n\s.*)*)\r\n").unwrap(),
+                Regex::new(r"(?im)^Message-ID: (.*(\n\s.*)*)\r\n").unwrap(),
             ),
             reply_to: Self::extract_field(
                 text,
-                Regex::new(r"(?i)Reply-To: (.*(\n\s.*)*)\r\n").unwrap(),
+                Regex::new(r"(?im)^Reply-To: (.*(\n\s.*)*)\r\n").unwrap(),
             ),
         }
     }
@@ -131,7 +131,7 @@ impl Outlook {
     fn extract_cc_from_headers(header_text: &str) -> Vec<Person> {
         // Format in header is:
         // CC: NAME <EMAIL>, NAME <EMAIL> \r\n
-        let re = Regex::new(r"(?i)CC: .*(\r\n\t)?.*\r\n").unwrap();
+        let re = Regex::new(r"(?im)CC: .*(\r\n\t)?.*\r\n").unwrap();
         let caps = re.captures(header_text);
         if caps.is_none() {
             return vec![];


### PR DESCRIPTION
I had Email headers like:

```
...
DKIM-Signature: a=rsa-sha256;v=1; c=relaxed/relaxed; d=mail.com; 
q=dns/txt; s=pic; t=1691516039; x=16927849 ;h=Message-Id: Reply-To: To: To: 
From: From: Subject: Subject: Content-Type: Mime-Version: Date: Sender:
Sender: List-Unsubscribe;bh=zjlrm5/tEtMJWQH4HX332WXO3W4U3AjIPbluPoe0=;
b=OmvSBhD0zzrSev6DkhEeghu0wxSTiWBgYn2new1eQ/Aw4ML5KuUIWUzVOcxdqnB514N87xA2346WveGXyD+uFMOQK11+hqnysrW3nfZzQKxV33Ury0/oAVG2EVTx9dXQDpf5QGG+gDe/oY1wKfFra7DkPNY2BKk6++Db9cdN7w=
DKIM-Signature: a=rsa-sha256;v=1; c=relaxed/relaxed; d=mail.com; 
q=dns/txt; s=pic; t=1691516039; x=16927849 ;h=Message-Id: Reply-To: To: To: 
From: From: Subject: Subject: Content-Type: Mime-Version: Date: Sender: 
Sender: List-Unsubscribe;bh=zjlrm5/tEtMJWQH4HX332WXO3W4U3AjIPbluPoe0=;
b=OmvSBhD0zzrSev6DkhEeghu0wxSTiWBgYn2new1eQ/Aw4ML5KuUIWUzVOcxdqnB514N87xA2346WveGXyD+uFMOQK11+hqnysrW3nfZzQKxV33Ury0/oAVG2EVTx9dXQDpf5QGG+gDe/oY1wKfFra7DkPNY2BKk6++Db9cdN7w=
X-Mailgun-Sending-Ip: 123.123.123.123
X-Mailgun-Sid: WyJh13wOCIsImFobWVkbjE5NjhA123uZGUiLCIzNTdiZDYiXQ==
List-Unsubscribe: <mailto: u+mq6tgnjxmjsdmjolbg44dcyjyhaywcobrmu3donjygu3ggjtjhvqwmbzgmydambrmvtdgnbrmmtha5ltnb2gky3ifvsgc5dbeu2uezdfnruxmzlspfpwszbfgvcd2nrumu2ggzrwmy2tqojxguydambqge3dantgmjtcm4dvonuhizldnawwiylumestkqttmvxgix3wmvzhg2lpnystkrb5gmxdalrqezzd2ylinvswi3rrhe3dqjjugb4wc2dpn4xgizjgoq6skmsb@mail.fghdfghdfgh.hdfghdfgh>
Received:from<unknown>(<unknown>[])by27d63123493c86a4withHTTPid64e4df7d5345349f3b56cc112bfe;Tue,22Aug202316:17:00GMT
X-Mailgun-Batch-Id: 64e4df7ccd2de71bad123b
Sender: <sender@mail.com>
Date: Tue, 01 Aug 2023 12:00:00+0000
MIME-Version: 1.0
Content-Type: multipart/alternative;
	boundary="25268e6f213454b0404afa5eba012344f7b1dc0bdb47e5c7666f2"
Subject: SUBJECT
From: Sender<sender@mail.com>
To: receiver@mail.com
Reply-To: cc@sender.com
...
```

The regex you had resulted in bad first matches. In this case it matched inside the **DKIM-Signature**. Giving bad values.
`Message-Id: Reply-To: To: To: 
From: From: Subject: Subject: Content-Type: Mime-Version: Date: Sender:`
I edited the regex, that the match has to be at the start of a line. To match the correct information from the bottom (in this example).